### PR TITLE
Add Cats Theory Primer: Reasoning and Revisions blog post

### DIFF
--- a/content/blog/category_theory/index.md
+++ b/content/blog/category_theory/index.md
@@ -1,7 +1,7 @@
 +++
 date = 2025-01-18
 authors = ["Josh Fairhead"]
-title = "Category Theory: A Primer for Non-Mathematicians"
+title = "Cats Theory Primer: Ground Zero"
 description = "An accessible introduction to category theory from the perspective of a tech product person"
 [taxonomies]
 tags = ["Exposition", "Mathematics", "Category Theory"]
@@ -9,21 +9,19 @@ tags = ["Exposition", "Mathematics", "Category Theory"]
 
 +++
 
-> TL;DR: This article provides an approachable introduction to category theory for those with a tech background but without formal mathematical training. Category theory offers a powerful framework that unifies much of mathematics through the elegant abstractions of objects and morphisms.
-
-## Introduction
+### Introduction
 
 Coming from a background in tech product development rather than pure mathematics or coding, I've recently begun exploring category theory. While I'm familiar with the work of J.G. Bennett and have been exposed to mathematical and programming concepts, I'm essentially starting from the ground up when it comes to formal category theory. This exposition shares what I've learned so far, presented in a way that hopefully makes these concepts accessible to others in similar positions.
 
-## Foundations: Beyond Set Theory
+### Foundations: Beyond Set Theory
 
 Traditional mathematics typically builds upon set theory as its foundation. However, category theory offers something different—and arguably more powerful. While sets and categories are fundamentally different constructs, category theory provides greater explanatory power and can integrate vast swaths of the mathematical landscape into a unified framework.
 
 Where set theory focuses on membership and elements, category theory emphasizes relationships and transformations. This shift in perspective proves remarkably fruitful for understanding mathematical structures and their interconnections.
 
-## The Basic Building Blocks
+### The Basic Building Blocks
 
-### Objects and Morphisms
+#### Objects and Morphisms
 
 If you're familiar with graph theory or network diagrams, you already understand the visual metaphor: nodes connected by edges. In category theory, these become:
 
@@ -32,18 +30,18 @@ If you're familiar with graph theory or network diagrams, you already understand
 
 A category consists of these objects and morphisms, bound together by three fundamental laws that ensure mathematical coherence.
 
-### The Three Laws
+#### The Three Laws
 
-#### 1. Identity
+##### 1. Identity
 Every object must have an identity morphism—an arrow that loops back to itself. This self-referential morphism leaves the object unchanged, much like multiplying by 1 or adding 0 in arithmetic. Visually, this appears as a loop starting and ending at the same object.
 
-#### 2. Associativity
+##### 2. Associativity
 When we have multiple morphisms connecting objects, the order in which we group them doesn't matter. If we have morphisms f, g, and h that can be composed, then (f ∘ g) ∘ h = f ∘ (g ∘ h). This property ensures consistency in how we navigate through our categorical structures.
 
-#### 3. Composition
+##### 3. Composition
 Perhaps the most powerful law: whenever we have a path from object A to B, and another from B to C, there must exist a direct morphism from A to C that represents their composition. We say this diagram "commutes"—meaning all paths between the same endpoints are equivalent. This creates a rich network of relationships where indirect connections imply direct ones.
 
-## Types of Morphisms
+### Types of Morphisms
 
 Morphisms come in various flavors, each capturing different mathematical relationships:
 
@@ -52,9 +50,9 @@ Morphisms come in various flavors, each capturing different mathematical relatio
 - **Isomorphism**: Morphisms with perfect two-way correspondence—essentially saying two objects are "the same" from the category's perspective
 - **Homomorphism**: Structure-preserving transformations that maintain the essential properties while mapping between objects
 
-## Higher-Order Structures
+### Higher-Order Structures
 
-### Functors: Morphisms Between Categories
+#### Functors: Morphisms Between Categories
 
 Just as morphisms connect objects within a category, functors connect entire categories to each other. A functor maps:
 - Objects in one category to objects in another
@@ -63,7 +61,7 @@ Just as morphisms connect objects within a category, functors connect entire cat
 
 This creates a second-order pattern where categories themselves become objects in a higher-level view, connected by functors as their morphisms.
 
-### The Hierarchy Continues
+#### The Hierarchy Continues
 
 This pattern of abstraction continues indefinitely in higher category theory:
 - **2-categories**: Categories where morphisms between morphisms (called 2-morphisms) exist
@@ -72,7 +70,7 @@ This pattern of abstraction continues indefinitely in higher category theory:
 
 Each level maintains the same fundamental pattern of objects and arrows, creating a fractal-like structure of mathematical relationships.
 
-## Further Exploration
+### Further Exploration
 
 This primer barely scratches the surface. Key topics for deeper investigation include:
 - Natural transformations

--- a/content/blog/cats_theory_reasoning_revisions/index.md
+++ b/content/blog/cats_theory_reasoning_revisions/index.md
@@ -1,0 +1,48 @@
++++
+date = 2025-01-19
+authors = ["Josh Fairhead"]
+title = "Cats Theory Primer: Reasoning and Revisions"
+description = "Addressing critiques and diving deeper into the fundamentals of category theory through examples and definitions"
+[taxonomies]
+tags = ["Exposition", "Mathematics", "Category Theory"]
+[extra]
+
++++
+
+### Reflection on Feedback
+
+Sharing my last post, the critique was blunt, "nothing here that you can't find in an introductory book on Category Theory" - which is probably true but having never read one, I couldn't tell you! 
+
+Two books I've been recommended for beginners requiring almost no background:
+1) Computational Category Theory 
+2) Category Theory for Programmers
+
+The constructive element of the critique asked some questions; namely whats and object and morphism? How are they defined? Provide an example of these. What is a category, provide an example, how do you split categories into different types? So here is an attempt at answering:
+
+### What is an Object?
+
+An object is a conceptual placeholder. You might consider it a point, which would indeed be an object but it's more general better thought of as an element in a space. In this example an element is an object in topological space.
+
+### What is a Morphism?
+
+A morphism is a conceptual mapping. You might consider it a line or arrow, which would indeed be a morphism again but it's probably better thought of as a mapping between objects. In this example a line would be a morphism in topological space.
+
+### What is a Category?
+
+A category is a conceptual space. At this point, we run into difficulty relying on the topology analogy. If we were to keep going with that general path of abstraction we would say its a plane because that's the next topological level, but I'm pretty sure the theorists would start shouting about that. 
+
+Let's wrestle with this alligator. Based on the previous definition that a category requires identity, association and composition I'm going to go out on a limb and define it for now as a third order logic - I can hear the theorists shouting already! 
+
+As far as I'm aware a category is a very abstract concept which means it generalises. A map is a generalisation of the territory. A menu is an abstraction of the meal. A category is an abstraction of a set of items with the named properties of identity, associativity and composition. It's not the set, its the tools that act as a visor. 
+
+### A Topological Example
+
+In the example of topology the object has the identity of being a point, if we multiply a point by itself we get itself, so we have identity. A line connecting between two points is associativity; a mapping from one to another, so we have association. If we add a third point and another connection we can follow the connectives from the first point to third point, via the second A > B > C - but we could just as easily map from A > C; this is composition. The lingo here is that its said to 'commute'. Hence in by the definitions I've provided, a simple polygon or plane is a category. 
+
+This is probably not useful. Who cares if a plane is a category? I don't, but working through this example helps show that CT goes beyond true/false boolean logic and is more relational in its nature. So why is category theory important? Because it's a dynamic form of maths that makes it suitable for coming to understanding rather than just knowledge - at this point, according to Bennetts General Systematics, we can say that its a triadic symbolic language.
+
+### Types of Categories
+
+This point seems both a good point to stop, but also a point of transition to the remaining questions of "how do you split categories up? (for example free categories vs non-free categories)" which is where I'm shakey and don't actually know, I'll have to look up the definitions, make inferences, ask questions and express my best approximation...
+
+A post for next time.


### PR DESCRIPTION
## Summary
- Updated existing Category Theory blog post to "Cats Theory Primer: Ground Zero" with reduced heading sizes and removed TLDR
- Added new blog post "Cats Theory Primer: Reasoning and Revisions" addressing feedback and diving deeper into definitions

## Test plan
- [ ] Verify both blog posts render correctly on the site
- [ ] Check that navigation between related posts works
- [ ] Confirm metadata and taxonomies are properly set

🤖 Generated with [Claude Code](https://claude.ai/code)