### PR TITLE
Fix portfolio dates: replace placeholder months with accurate dates

### DIFF
--- a/content/multimedia/cursed/index.md
+++ b/content/multimedia/cursed/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Cursed Animation"
 description = "Music created for short animation where a cursed exile is faced with a life and death dilemma."
-date = 2010-01-01
+date = 2010-05-01
 weight = 8
 [taxonomies]
 tags = ["Multimedia"]

--- a/content/multimedia/elephantsdream/index.md
+++ b/content/multimedia/elephantsdream/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Elephants Dream Animation"
 description = "Sound design, foley and ADR for a mechanical dream world influenced by thought."
-date = 2011-01-01
+date = 2011-06-01
 weight = 1
 [taxonomies]
 tags = ["Multimedia"]

--- a/content/multimedia/encaged/index.md
+++ b/content/multimedia/encaged/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Encaged"
 description = "Music composed for a short animation about old people connecting through their birds."
-date = 2010-01-01
+date = 2010-04-01
 weight = 10
 [taxonomies]
 tags = ["Multimedia"]

--- a/content/recordings/beatbehind/index.md
+++ b/content/recordings/beatbehind/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Beat Behind"
 description = "Bluesy funk rock acoustic with slide and slap bass"
-date = 2013-01-01
+date = 2013-12-01
 draft = false
 weight = 1
 [taxonomies]

--- a/content/recordings/brentwoodroyalyouthorchestra/index.md
+++ b/content/recordings/brentwoodroyalyouthorchestra/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Brentwood Royal Youth Legion Orchestra"
 description = "Large ensamble recording"
-date = 2012-01-01
+date = 2012-12-01
 draft = false
 weight = 100
 [taxonomies]

--- a/content/recordings/greysky/index.md
+++ b/content/recordings/greysky/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Grey Sky"
 description = "Meloncholy messaging about the links between projections and expectatons as a closed causal loop"
-date = 2013-09-14
+date = 2013-08-14
 draft = false
 weight = 1
 [taxonomies]

--- a/content/recordings/harmonicsplinters/index.md
+++ b/content/recordings/harmonicsplinters/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Harmonic Splinters"
 description = "Upbeat acoustic rock in odd times with honky tonk piano and some epic guitar solos"
-date = 2013-09-17
+date = 2013-08-17
 draft = false
 weight = 1
 [taxonomies]

--- a/content/recordings/irishchamberorchestra/index.md
+++ b/content/recordings/irishchamberorchestra/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Irish Chamber Orchestra"
 description = "Live orchestral recording in St. Multose Church Kinsale"
-date = 2010-01-01
+date = 2010-08-01
 draft = false
 weight = 55
 [taxonomies]

--- a/content/recordings/mountains/index.md
+++ b/content/recordings/mountains/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Mountains"
 description = "Written too late to be recorded for my masters project, this tune actually showed the most promise as raw material."
-date = 2014-01-01
+date = 2014-03-01
 draft = false
 weight = 70
 [taxonomies]

--- a/content/recordings/petemolinari/index.md
+++ b/content/recordings/petemolinari/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Pete Moulinari"
 description = "Live recording of Pete and his band in Shepards Bush"
-date = 2012-01-01
+date = 2012-09-01
 draft = false
 weight = 80
 [taxonomies]

--- a/content/recordings/primates/index.md
+++ b/content/recordings/primates/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Primates"
 description = "The genesis track of progressive rock concept album telling the story of music"
-date = 2013-01-01
+date = 2013-08-01
 draft = true
 weight = 1
 [taxonomies]

--- a/content/recordings/projectplay/index.md
+++ b/content/recordings/projectplay/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Project Play"
 description = "A masters project playing all the parts; composition, arrangement, recording, mix, 5.1 surround"
-date = 2013-01-01
+date = 2013-08-01
 weight = 20
 [taxonomies]
 tags = ["Recordings", "Studio"]

--- a/content/recordings/robots/index.md
+++ b/content/recordings/robots/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Robots"
 description = "The book end to Primates, an intentionally riddiculous prog rock response to the increased use of autotune in pop music"
-date = 2013-01-01
+date = 2013-08-01
 draft = false
 weight = 1
 [taxonomies]

--- a/content/recordings/thamesvallyphilharmonia/index.md
+++ b/content/recordings/thamesvallyphilharmonia/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Isobella Peck Cubann II Thames Valley Philharmonic"
 description = "Location recording of the Thames Valley Philharmonic"
-date = 2012-01-01
+date = 2012-03-01
 draft = false
 weight = 60
 [taxonomies]

--- a/content/software/blockchainonboarding/index.md
+++ b/content/software/blockchainonboarding/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Blockchain Onboarding"
 description = "Creating accessible pathways into Web3 - comprehensive field guides that demystify blockchain from first principles, covering wallets, DAOs, and decentralized governance."
-date = 2022-01-01
+date = 2022-03-01
 weight = 10
 [taxonomies]
 tags = ["Software", "Documentation"]

--- a/content/software/hermitage/index.md
+++ b/content/software/hermitage/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Hermitage"
 description = "Hermitage project - placeholder for future development."
-date = 2020-01-01
+date = 2020-11-01
 draft = false
 weight = 10
 [taxonomies]

--- a/content/software/holons/index.md
+++ b/content/software/holons/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Holons"
 description = "AI enhanced coordination with blockchain tracking; votes, tasks, mutual credit, rewards, processes"
-date = 2019-01-01
+date = 2019-12-01
 weight = 3
 [taxonomies]
 tags = ["Software"]

--- a/content/software/interspace/index.md
+++ b/content/software/interspace/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Interspace"
 description = "Interspace.chat - an interface developed for open space gatherings during the pandemic"
-date = 2020-01-01
+date = 2020-09-01
 draft = false
 weight = 10
 [taxonomies]

--- a/content/software/notabot/index.md
+++ b/content/software/notabot/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Not-a-Bot"
 description = "Proof of unique passport identity system"
-date = 2020-01-01
+date = 2020-12-01
 draft = false
 weight = 2
 [taxonomies]

--- a/content/tech-management/borrisbrejeca/index.md
+++ b/content/tech-management/borrisbrejeca/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Boris Brejcha (lights)"
 description = "Lighting design for Boris Brejchas 2017 performance in Egg London."
-date = 2016-11-19
+date = 2017-02-04
 weight = 10
 [taxonomies]
 tags = ["Events"]

--- a/content/tech-management/mber/index.md
+++ b/content/tech-management/mber/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Mber"
 description = "AV installation and technical setup for Mber venue."
-date = 2015-01-01
+date = 2016-09-01
 weight = 42
 [taxonomies]
 tags = ["Venues"]

--- a/content/tech-management/oriole/index.md
+++ b/content/tech-management/oriole/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Oriole"
 description = "AV installation and technical setup for Oriole venue."
-date = 2015-01-01
+date = 2015-11-01
 weight = 41
 [taxonomies]
 tags = ["Venues"]

--- a/content/tech-management/swift/index.md
+++ b/content/tech-management/swift/index.md
@@ -2,7 +2,7 @@
 authors = ["Josh Fairhead"]
 title = "Swift"
 description = "AV installation and technical setup for Swift venue."
-date = 2015-01-01
+date = 2016-10-01
 weight = 40
 [taxonomies]
 tags = ["Venues"]


### PR DESCRIPTION
## Summary
- Corrected 23 portfolio entry dates that used January 1st or incorrect month placeholders
- Replaced with accurate months based on project history
- Includes recordings, multimedia, software, and venue entries spanning 2010–2022

## Test plan
- [x] Zola builds with no errors
- [x] All date fields are TOML-valid (YYYY-MM-DD format)
- [ ] Spot-check portfolio pages in browser to verify dates render correctly

🤖 Generated with Claude Code