### PR TITLE
Replace nav menu with tag-based portfolio filtering

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,17 +28,13 @@ show_reading_time = true
 csp = false
 
 styles = []
+scripts = ["tag-filter.js"]
 
 [extra.nav]
 show_feed = false
 show_theme_switcher = false
 show_repo = false
-links = [
-    { name = "Software", url = "software" },
-    { name = "Recordings", url = "recordings" },
-    { name = "Multimedia", url = "multimedia" },
-    { name = "Tech Management", url = "tech-management" },
-]
+links = []
 
 [extra.footer]
 links = []

--- a/content/software/adaptivecapital/index.md
+++ b/content/software/adaptivecapital/index.md
@@ -5,7 +5,7 @@ description = "Tokenomics proposal for the regen network, proposing a multi pers
 date = 2023-09-11
 weight = 10
 [taxonomies]
-tags = ["Software", "Proposal"]
+tags = ["Software", "Documentation"]
 [extra]
 banner = "thumbnail.jpg"
 hero = false

--- a/sass/_custom.scss
+++ b/sass/_custom.scss
@@ -115,3 +115,84 @@ main {
         grid-template-columns: 1fr;
     }
 }
+
+/* Tag filter: word cloud in left margin on desktop */
+.tag-filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding: 0;
+    margin-bottom: 1rem;
+}
+
+@media (min-width: 769px) {
+    .tag-filter-bar {
+        position: absolute;
+        top: 0;
+        right: calc(100% + 1rem);
+        width: 240px;
+        margin-bottom: 0;
+        justify-content: flex-end;
+    }
+
+    .content-card-grid {
+        position: relative;
+    }
+}
+
+.tag-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.625rem 0.75rem;
+    border: none;
+    border-radius: 999px;
+    background-color: var(--fg-muted-1);
+    color: var(--fg-muted-4);
+    font-size: var(--font-size-medium, 0.875rem);
+    font-weight: bold;
+    font-family: inherit;
+    cursor: pointer;
+    transition: var(--transition, 0.2s);
+    line-height: 1;
+    white-space: nowrap;
+    box-shadow: none;
+    text-decoration: none;
+
+    &:hover {
+        box-shadow: var(--edge-highlight);
+        background-color: var(--fg-muted-3);
+        color: var(--fg-color);
+    }
+
+    &.active {
+        box-shadow: var(--edge-highlight);
+        background-color: var(--accent-color-alpha);
+        color: var(--accent-color);
+
+        &:hover {
+            background-color: var(--accent-color);
+            color: var(--contrast-color);
+        }
+    }
+
+    &:active {
+        transform: var(--active, scale(0.95));
+    }
+}
+
+.tag-pill__count {
+    font-size: var(--font-size-small, 0.75rem);
+    opacity: 0.7;
+}
+
+/* Make card tags look clickable */
+.content-card__tag[data-card-tag] {
+    cursor: pointer;
+    transition: var(--transition, 0.2s);
+
+    &:hover {
+        background: var(--accent-color-alpha, rgba(30, 64, 175, 0.1));
+        color: var(--accent-color);
+    }
+}

--- a/static/tag-filter.js
+++ b/static/tag-filter.js
@@ -1,0 +1,101 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var filterBar = document.getElementById('tag-filter');
+  var cardGrid = document.getElementById('card-grid');
+
+  if (!filterBar || !cardGrid) return;
+
+  var pills = filterBar.querySelectorAll('.tag-pill');
+  var cards = cardGrid.querySelectorAll('.content-card');
+  var activeTags = new Set();
+
+  function getTagsFromURL() {
+    var params = new URLSearchParams(window.location.search);
+    var tagsParam = params.get('tags');
+    if (tagsParam) {
+      return tagsParam.split(',').map(function (t) { return t.trim(); });
+    }
+    return [];
+  }
+
+  function updateURL() {
+    var url = new URL(window.location);
+    if (activeTags.size === 0) {
+      url.searchParams.delete('tags');
+    } else {
+      url.searchParams.set('tags', Array.from(activeTags).join(','));
+    }
+    window.history.replaceState({}, '', url);
+  }
+
+  function filterCards() {
+    var showAll = activeTags.size === 0;
+
+    cards.forEach(function (card) {
+      var cardTags = (card.getAttribute('data-tags') || '')
+        .split(',')
+        .map(function (t) { return t.trim(); })
+        .filter(function (t) { return t.length > 0; });
+
+      var visible;
+      if (showAll) {
+        visible = true;
+      } else {
+        visible = Array.from(activeTags).every(function (tag) {
+          return cardTags.indexOf(tag) !== -1;
+        });
+      }
+
+      card.style.display = visible ? '' : 'none';
+    });
+
+    pills.forEach(function (pill) {
+      var tag = pill.getAttribute('data-tag');
+      if (tag === 'all') {
+        pill.classList.toggle('active', activeTags.size === 0);
+      } else {
+        pill.classList.toggle('active', activeTags.has(tag));
+      }
+    });
+
+    updateURL();
+  }
+
+  pills.forEach(function (pill) {
+    pill.addEventListener('click', function () {
+      var tag = pill.getAttribute('data-tag');
+      if (tag === 'all') {
+        activeTags.clear();
+      } else {
+        if (activeTags.has(tag)) {
+          activeTags.delete(tag);
+        } else {
+          activeTags.add(tag);
+        }
+      }
+      filterCards();
+    });
+  });
+
+  cardGrid.addEventListener('click', function (e) {
+    var tagEl = e.target.closest('[data-card-tag]');
+    if (tagEl) {
+      e.preventDefault();
+      e.stopPropagation();
+      var tag = tagEl.getAttribute('data-card-tag');
+      if (activeTags.has(tag)) {
+        activeTags.delete(tag);
+      } else {
+        activeTags.add(tag);
+      }
+      filterCards();
+    }
+  });
+
+  var urlTags = getTagsFromURL();
+  urlTags.forEach(function (tag) {
+    activeTags.add(tag);
+  });
+  if (activeTags.size > 0) {
+    filterCards();
+  }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,30 @@
+{% import "macros/rel_attributes.html" as macros_rel_attributes %}
+{% import "macros/translate.html" as macros_translate %}
+
+{%- set language_strings = load_data(path="i18n/" ~ lang ~ '.toml', required=false) -%}
+{%- if not language_strings -%}
+    {%- set language_strings = load_data(path="themes/duckquill/i18n/" ~ lang ~ ".toml", required=false) -%}
+{%- endif -%}
+{%- set rtl_languages = ["ar", "arc", "az", "dv", "ff", "he", "ku", "nqo", "fa", "rhg", "syc", "ur"] -%}
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" {% if lang in rtl_languages %}dir="rtl"{% endif %} lang="{{ lang }}" {% include "partials/default_theme.html" %}>
+{% include "partials/head.html" %}
+<body>
+{% block body %}
+{%- if page.extra.toc_sidebar or section.extra.toc_sidebar -%}
+		<div id="sidebar">
+			<div>
+				{%- include "partials/toc.html" -%}
+			</div>
+		</div>
+	{%- endif -%}
+	<main id="main-content">
+		{% block custom %}{% endblock custom %}
+		{% block content %}{% endblock content %}
+		{% include "partials/extra_features.html" %}
+	</main>
+	{% include "partials/footer.html" %}
+{% endblock body %}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,40 @@
 {% block content %}
 <h1>{{ section.title }}</h1>
 
+{% set all_tags = get_taxonomy(kind="tags") %}
 {% set pages = section.pages %}
-{% include "partials/card_grid.html" %}
+<div class="content-card-grid" id="card-grid">
+    <div id="tag-filter" class="tag-filter-bar">
+        <button class="tag-pill active" data-tag="all">All</button>
+        {% for term in all_tags.items %}
+        <button class="tag-pill" data-tag="{{ term.name }}">{{ term.name }}</button>
+        {% endfor %}
+    </div>
+    {% for page in pages %}
+    <a href="{{ page.permalink }}" class="content-card"
+       data-tags="{{ page.taxonomies.tags | default(value=[]) | join(sep=',') }}">
+        {% if page.extra.card or page.extra.banner %}
+        <div class="content-card__banner">
+            <img src="{{ page.permalink }}{{ page.extra.card | default(value=page.extra.banner) | safe }}" alt="{{ page.title }}" loading="lazy" />
+        </div>
+        {% endif %}
+        <div class="content-card__info">
+            <h3 class="content-card__title">{{ page.title }}</h3>
+            {% if page.date %}
+            <time class="content-card__date">{{ page.date | date(format="%B %Y") }}</time>
+            {% endif %}
+            {% if page.description %}
+            <p class="content-card__description">{{ page.description }}</p>
+            {% endif %}
+            {% if page.taxonomies.tags %}
+            <div class="content-card__tags">
+                {% for tag in page.taxonomies.tags %}
+                <span class="content-card__tag" data-card-tag="{{ tag }}">{{ tag }}</span>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+    </a>
+    {% endfor %}
+</div>
 {% endblock content %}

--- a/templates/partials/card_grid.html
+++ b/templates/partials/card_grid.html
@@ -1,6 +1,7 @@
-<div class="content-card-grid">
+<div class="content-card-grid" id="card-grid">
     {% for page in pages %}
-    <a href="{{ page.permalink }}" class="content-card">
+    <a href="{{ page.permalink }}" class="content-card"
+       data-tags="{{ page.taxonomies.tags | default(value=[]) | join(sep=',') }}">
         {% if page.extra.card or page.extra.banner %}
         <div class="content-card__banner">
             <img src="{{ page.permalink }}{{ page.extra.card | default(value=page.extra.banner) | safe }}" alt="{{ page.title }}" loading="lazy" />
@@ -17,7 +18,7 @@
             {% if page.taxonomies.tags %}
             <div class="content-card__tags">
                 {% for tag in page.taxonomies.tags %}
-                <span class="content-card__tag">{{ tag }}</span>
+                <span class="content-card__tag" data-card-tag="{{ tag }}">{{ tag }}</span>
                 {% endfor %}
             </div>
             {% endif %}

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -1,0 +1,16 @@
+<header id="site-nav">
+	<nav>
+		<a href="#main-content" tabindex="0">Skip to Main Content</a>
+		<ul>
+			<li id="home">
+				<a href="{{ get_url(path='/') }}"
+					{%- if current_url | default(value="/") | trim_end_matches(pat="/") | safe == get_url(path="/") | trim_end_matches(pat='/') | safe -%}
+						class="active"
+					{%- endif -%}>
+					<i class="icon"></i>
+					{{- config.title -}}
+				</a>
+			</li>
+		</ul>
+	</nav>
+</header>


### PR DESCRIPTION
## Summary
- Replaces the 4 section nav links (Software, Recordings, Multimedia, Tech Management) with interactive tag pill buttons for client-side filtering on the index page
- Tag pills appear as a word cloud in the left margin on desktop, inline on mobile
- Supports URL query params (`?tags=Software,Studio`) for shareable pre-filtered portfolio views, enabling a "hub" use case where links can be tailored per employer
- Removes the nav bar entirely since tag pills now serve as navigation
- Fixes Adaptive Capital's tag from "Proposal" to "Documentation"

## Test plan
- [ ] Verify tag pills render on index page and filter cards on click
- [ ] Test multi-select (AND logic — selecting more tags narrows results)
- [ ] Test URL params: visit `/?tags=Software` and confirm pre-filtering
- [ ] Confirm section pages (`/software/`, `/recordings/`) still accessible directly
- [ ] Check responsive layout: pills above cards on mobile, left margin on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)