### PR TITLE
Add Live tag to Boris Brejcha and Eric Morillo

### DIFF
--- a/content/tech-management/borrisbrejeca/index.md
+++ b/content/tech-management/borrisbrejeca/index.md
@@ -5,7 +5,7 @@ description = "Lighting design for Boris Brejchas 2017 performance in Egg London
 date = 2017-02-04
 weight = 10
 [taxonomies]
-tags = ["Events"]
+tags = ["Events", "Live"]
 [extra]
 banner = "thumbnail.jpg"
 hero = false

--- a/content/tech-management/ericmorillo/index.md
+++ b/content/tech-management/ericmorillo/index.md
@@ -5,7 +5,7 @@ description = "Lighting design for Eric Morillos 2016 performance in Egg London.
 date = 2016-11-19
 weight = 10
 [taxonomies]
-tags = ["Events"]
+tags = ["Events", "Live"]
 [extra]
 banner = "thumbnail.jpg"
 hero = false


### PR DESCRIPTION
Adds the "Live" tag to the Boris Brejcha and Eric Morillo portfolio posts, which previously only had the "Events" tag. This enables these posts to appear under the "Live" tag filter on the index page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)