### PR TITLE
Add professional CV timeline entries

### DIFF
--- a/content/software/hermitage/index.md
+++ b/content/software/hermitage/index.md
@@ -1,8 +1,8 @@
 +++
 authors = ["Josh Fairhead"]
 title = "Hermitage"
-description = "Capabilities management interface for digital identity system on a distributed hash table"
-date = 2020-11-01
+description = "Holochain interface prototype for self-sovereign data management, winner of Odyssey Momentum SSI track"
+date = 2019-11-01
 draft = false
 weight = 10
 [taxonomies]
@@ -20,6 +20,10 @@ Hermitage was an early prototype of a Holochain interface where users could inte
 {{ image(url="/images/hermitage/hermitagescreen04.png", alt="Hermitage alternative persona field selector", no_hover=true) }}
 {{ image(url="/images/hermitage/hermitagescreen05.png", alt="Hermitage profiles view with persona and filter options", no_hover=true) }}
 {{ image(url="/images/hermitage/hermitagescreen06.png", alt="Hermitage persona management", no_hover=true) }}
+
+## Odyssey Momentum
+
+Hermitage was built at Odyssey Momentum (November 2019), the second Odyssey hackathon following the Commons Stack's success at Odyssey 2019. The project won "Best Multidisciplinary Approach" sponsored by the Dutch Blockchain Coalition in the Self-Sovereign Identity track. This recognition led to consulting engagements with Akasha Hub and the Dutch Blockchain Coalition.
 
 ## Repo
 

--- a/content/software/holons/index.md
+++ b/content/software/holons/index.md
@@ -20,6 +20,8 @@ TODO: Replace text with the readme from github
 
 -->
 
+Holons was developed in the context of Liminal Village, a co-living and co-creation hub in Italy focused on permaculture, ecological restoration, and alternative technology.
+
 [Holons](https://www.holons.io/) is an innovative organizational coordination platform that enables the creation of adaptive, interconnected organizations mirroring natural network structures. Built as an open protocol, it integrates Telegram-based coordination with AI-enhanced resource allocation and blockchain tracking.
 
 The platform supports decentralized, nested organizational structures inspired by natural systems - from cells to societies.

--- a/content/timeline/_index.md
+++ b/content/timeline/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Career"
+sort_by = "date"
+transparent = true
+template = "section.html"
+page_template = "article.html"
+[extra]
+hero = false
++++
+
+Professional roles and organizational work.

--- a/content/timeline/commonsstack/index.md
+++ b/content/timeline/commonsstack/index.md
@@ -1,0 +1,37 @@
++++
+authors = ["Josh Fairhead"]
+title = "Commons Stack"
+description = "Ecosystems development, hackathon coordination, and cryptoeconomic mechanism design for commons governance"
+date = 2018-10-01
+draft = true
+weight = 10
+[taxonomies]
+tags = ["CV"]
+[extra]
+banner = ""
+hero = false
++++
+
+Ecosystems Development at the Commons Stack (2018-2019), catalysing its launch through narrative development based on Elinor Ostrom's *Governing the Commons*, hackathon organisation, community management, and cross-team coordination.
+
+## The Meta-Hack
+
+At Odyssey 2019 - hosted on a pirate ship called "Mars" - I served as a "Jedi" focused on networking and communication between teams. A five-team strategy coordinated 25 people working on interconnected aspects of the Commons Stack. Three of five teams won prizes, validating the collaborative approach and covering the boat costs.
+
+The concept crystallised from a sequence of hackathons and conversations with BlockScience contributors, Giveth community members, and token engineering researchers. Rather than building another DeFi protocol, we were creating technical infrastructure to enable different forms of human coordination - a "load balancer for society."
+
+## Five-Module Architecture
+
+**Proposal Framework (Giveth 2.0):** Refactored donation and project coordination system on xDai (Gnosis Chain)
+
+**Continuous Signalling Mechanism:** Stake-weighted proposal support with natural decay - passive by design, active by choice
+
+**Curved Bonding Engine:** Mathematical relationships for continuous community funding and dynamic resource allocation
+
+**Reputation and Attestation Network:** Built on SourceCred's contribution tracking, mapping flows of value including typically unrecognised contributions (emotional labour, facilitation, translation)
+
+**Fair-Trade Mutual Credit System:** Value exchange without debt-based money creation, based on actual productive capacity
+
+## Links
+
+- [Commons Stack](https://www.commonsstack.org/)

--- a/content/timeline/giveth/index.md
+++ b/content/timeline/giveth/index.md
@@ -1,0 +1,29 @@
++++
+authors = ["Josh Fairhead"]
+title = "Giveth"
+description = "Contributing to Giveth's biomimetic curation DAO with stigmergic governance mechanisms"
+date = 2018-09-01
+draft = true
+weight = 10
+[taxonomies]
+tags = ["CV"]
+[extra]
+banner = ""
+hero = false
++++
+
+After leaving Pillar, I connected with the Giveth community at the Web3 Summit in Berlin. Over falafel with co-founder Griff Green, we explored how cryptoeconomic primitives - token curated registries, bonding curves, and webs of trust - might work together under a commons governance framework inspired by Elinor Ostrom.
+
+## Giveth 2.0
+
+Giveth was a crypto charity experimenting with transparent, decentralised funding mechanisms for public goods. I contributed to the vision for Giveth 2.0 - a biomimetic curation DAO with stigmergic governance mechanisms, designed to work on xDai (now Gnosis Chain) and incorporating lessons from years of operating the original platform.
+
+## The Hackathon Circuit
+
+The Berlin conversations snowballed into a speed-run of the 2019 hackathon circuit: AraCon (Jan 28-30), ETH Denver (Feb 15-17), ETH CC (Mar 5-7), ETH Paris (Mar 8-10), and warmup events leading to Odyssey. The original Giveth hackteam branded themselves "Pactful" and competed at ETH Denver for social impact prizes.
+
+These events catalysed what would become the Commons Stack - a larger collaborative effort emerging from the convergence of Giveth's community, BlockScience's token engineering research, and new contributors encountered along the circuit.
+
+## Links
+
+- [Giveth](https://giveth.io)

--- a/content/timeline/liminalvillage/index.md
+++ b/content/timeline/liminalvillage/index.md
@@ -1,0 +1,31 @@
++++
+authors = ["Josh Fairhead"]
+title = "Liminal Village"
+description = "Stewardship, design and innovation at a co-living community of practice in permaculture, ecological restoration and technology"
+date = 2019-06-01
+draft = true
+weight = 10
+[taxonomies]
+tags = ["CV"]
+[extra]
+banner = ""
+hero = false
++++
+
+Stewardship, Design and Innovation at Liminal Village (2019-2020), a co-living and co-creation hub in Italy focused on permaculture, ecological restoration, systems thinking, and alternative technology.
+
+## Role
+
+Coordinated a community of practice engaging in:
+
+- Permaculture and ecological restoration
+- Systems thinking and facilitation
+- Event organisation and design
+- Technical project coordination for [holons.io](https://www.holons.io/)
+
+Liminal Village provided the context for developing Holons - an organisational coordination platform enabling adaptive, interconnected organisations mirroring natural network structures.
+
+## Links
+
+- [Liminal Village](https://www.liminalvillage.com/)
+- [Holons](https://www.holons.io/)

--- a/content/timeline/pillar/index.md
+++ b/content/timeline/pillar/index.md
@@ -1,0 +1,35 @@
++++
+authors = ["Josh Fairhead"]
+title = "Pillar Project"
+description = "Product management, research, design and development for a cryptocurrency wallet from first principles"
+date = 2017-06-01
+draft = true
+weight = 10
+[taxonomies]
+tags = ["CV"]
+[extra]
+banner = ""
+hero = false
++++
+
+Product Manager at Pillar Project (2017-2018), building a personal data locker using blockchain technology to give individuals control over their data. The core vision inverted the internet from data-centric to human-centric design, with the wallet acting as the "mother app" - a unified interface for managing digital identity, data sharing permissions, and application interactions.
+
+## Scope
+
+The work spanned multiple specialised domains across the entire product lifecycle:
+
+**Cryptographic Systems:** Proxy key management, account abstraction, messaging protocols, and distributed identity infrastructure
+
+**Regulatory Compliance:** KYC/AML implementation, GDPR compliance frameworks, and emerging data protection regulations
+
+**Product & UX:** Persona development, user stories, wireframing, and simplifying complex cryptographic operations into intuitive user flows
+
+**Market Intelligence:** Competitive landscape mapping, integration partner analysis, and regulatory environment monitoring
+
+**Growth & Communications:** Marketing strategy based on the SoundCloud growth stack using Snowplow as a metrics multiplexer, supporting A/B testing and growth optimisation
+
+## Key Outcomes
+
+- Shipped wallet v1 to thousands of users
+- Organised 600-person unconference event
+- Helped scale organisation from 7 to approximately 60 people in the first year

--- a/content/timeline/regenfoundation/index.md
+++ b/content/timeline/regenfoundation/index.md
@@ -1,0 +1,31 @@
++++
+authors = ["Josh Fairhead"]
+title = "Regen Foundation"
+description = "Ledger governance coordination for delegated proof-of-stake community, bridging land stewards with blockchain technology"
+date = 2021-01-01
+draft = true
+weight = 10
+[taxonomies]
+tags = ["CV"]
+[extra]
+banner = ""
+hero = false
++++
+
+Ledger Governance Coordinator at Regen Foundation (2021-2022), coordinating proposal processes for a delegated proof-of-stake community and enabling collaboration between staking DAO delegators, validators, and developers.
+
+## Role
+
+- Facilitated community governance for 25+ person biweekly meetings
+- Educated land stewards about blockchain technology
+- Developed visual onboarding guides clarifying the roles of markets, science, and technology in relation to people, place, and planet
+- Coordinated collaboration between staking DAO delegators, validators, and developers
+
+## Context
+
+Regen Network is a blockchain platform focused on ecological regeneration and climate action. The Foundation supports the network's community governance processes, ensuring that decision-making remains accessible and inclusive for participants ranging from technical validators to place-based land stewards.
+
+## Links
+
+- [Regen Foundation](https://regen.foundation/)
+- [Regen Network](https://www.regen.network/)


### PR DESCRIPTION
## Summary
- Add 5 draft timeline entries (Pillar, Giveth, Commons Stack, Liminal Village, Regen Foundation) with `tags = ["CV"]`
- Update Hermitage with correct date (2019-11-01), improved description, and Odyssey Momentum section
- Update Holons with Liminal Village context
- New `content/timeline/` section with career index page

## Test plan
- [x] `zola build` passes with no errors
- [x] `zola serve` (without `--drafts`) shows 36 pages — new entries hidden
- [x] `zola serve --drafts` shows 43 pages — new entries visible
- [ ] Review draft content before removing `draft = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)